### PR TITLE
Attrs 

### DIFF
--- a/constraints-py26.txt
+++ b/constraints-py26.txt
@@ -6,3 +6,6 @@ jsonschema==2.5.1
 
 # Last release with Py26 support
 Twisted==15.4.0
+
+# First version to drop support for Py26, but it works
+attrs==16.0.0


### PR DESCRIPTION
Attrs dropped support in 16.0.0, but it does seem to work and provides the more up to date api. In fact - 15.2.0 did not work for current patterns of use for attrs - or at least how I have used them in qwobl.

I manually tested 16.0.0 on qa-notify.